### PR TITLE
Correction des erreurs de compilation des tests unitaires

### DIFF
--- a/src/main/java/com/project/training/MFCCSoundTrainer.java
+++ b/src/main/java/com/project/training/MFCCSoundTrainer.java
@@ -140,7 +140,7 @@ public class MFCCSoundTrainer extends BaseSoundTrainer {
     }
     
     @Override
-    protected MultiLayerNetwork getModel() {
+    public MultiLayerNetwork getModel() {
         // Initialiser le modèle si ce n'est pas déjà fait
         if (model == null) {
             initializeModel();

--- a/src/main/java/com/project/training/SpectrogramSoundTrainer.java
+++ b/src/main/java/com/project/training/SpectrogramSoundTrainer.java
@@ -365,7 +365,7 @@ public class SpectrogramSoundTrainer extends BaseSoundTrainer {
     }
     
     @Override
-    protected MultiLayerNetwork getModel() {
+    public MultiLayerNetwork getModel() {
         // Initialiser le modèle si ce n'est pas déjà fait
         if (model == null) {
             initializeModel();

--- a/src/test/java/com/project/test/MFCCSoundModelTester.java
+++ b/src/test/java/com/project/test/MFCCSoundModelTester.java
@@ -81,16 +81,16 @@ public class MFCCSoundModelTester extends BaseModelTester implements ModelTester
         // Vérifications spécifiques au modèle MFCC
         try {
             // Vérifier que la forme d'entrée est correcte
-            int[] inputShape = model.getLayerInputShape(0);
+            long[] inputShape = model.layerInputSize(0);
             int expectedInputSize = numMfcc * inputLength;
             
-            if (inputShape[1] != expectedInputSize) {
+            if (inputShape[0] != expectedInputSize) {
                 log.error("La taille d'entrée du modèle ({}) ne correspond pas à la taille attendue ({}) pour les MFCC", 
-                        inputShape[1], expectedInputSize);
+                        inputShape[0], expectedInputSize);
                 return false;
             }
             
-            log.info("Le modèle MFCC a la bonne forme d'entrée : {}", inputShape[1]);
+            log.info("Le modèle MFCC a la bonne forme d'entrée : {}", inputShape[0]);
             return true;
             
         } catch (Exception e) {

--- a/src/test/java/com/project/test/SoundTrainerTest.java
+++ b/src/test/java/com/project/test/SoundTrainerTest.java
@@ -79,9 +79,9 @@ public class SoundTrainerTest {
         int inputSize = Integer.parseInt(config.getProperty("sound.input.length", "16000")) * 
                         Integer.parseInt(config.getProperty("sound.num.mfcc", "40"));
         
-        int[] inputShape = model.getLayerInputShape(0);
+        long[] inputShape = model.layerInputSize(0);
         assertEquals("La taille d'entrée du modèle devrait correspondre aux paramètres", 
-                inputSize, inputShape[1]);
+                inputSize, inputShape[0]);
     }
     
     @Test

--- a/src/test/java/com/project/test/SpectrogramSoundModelTester.java
+++ b/src/test/java/com/project/test/SpectrogramSoundModelTester.java
@@ -129,7 +129,7 @@ public class SpectrogramSoundModelTester extends BaseModelTester implements Mode
             log.info("Architecture du modèle: {}", architecture);
             
             // Vérifier que la forme d'entrée est correcte
-            int[] inputShape = model.layerInputSize(0);
+            long[] inputShape = model.layerInputSize(0);
             
             if (inputShape[0] != channels || inputShape[1] != height || inputShape[2] != width) {
                 log.error("La forme d'entrée du modèle ([{}, {}, {}]) ne correspond pas à la forme attendue ([{}, {}, {}]) pour les spectrogrammes", 


### PR DESCRIPTION

## Corrections apportées

Cette PR corrige les problèmes de compilation des tests unitaires après la migration vers DL4J 1.0.0-beta7.

Les modifications incluent :

1. Changement de visibilité de la méthode `getModel()` dans `MFCCSoundTrainer` et `SpectrogramSoundTrainer` de 'protected' à 'public' pour permettre l'accès depuis les tests.

2. Mise à jour de la méthode `getLayerInputShape(int)` qui n'existe plus dans DL4J 1.0.0-beta7, remplacée par `layerInputSize(int)` qui retourne un `long[]` au lieu d'un `int[]`.

3. Correction des types dans `SpectrogramSoundModelTester.java` pour gérer le retour de type `long[]` au lieu de `int[]`.

Ces modifications permettent une compilation réussie des tests unitaires et sont compatibles avec la version beta7 de DL4J.
